### PR TITLE
Update the priorities of city aliases in geocoder.ex

### DIFF
--- a/lib/teslamate/locations/geocoder.ex
+++ b/lib/teslamate/locations/geocoder.ex
@@ -102,8 +102,8 @@ defmodule TeslaMate.Locations.Geocoder do
   @city_aliases [
     "city",
     "town",
-    "municipality",
     "village",
+    "municipality",
     "hamlet",
     "locality",
     "croft"


### PR DESCRIPTION
To fix #1030, by moving the priority of "village" higher than "municipality".